### PR TITLE
Swap MessageCreatedSubscription useEffect with onSubscriptionData

### DIFF
--- a/web/src/components/feed/feed.tsx
+++ b/web/src/components/feed/feed.tsx
@@ -1,37 +1,48 @@
 import { FEED_MAX_SIZE, ICON_MAP } from "./constants";
 
 import { useProviders } from "../../context/providers.context";
+import client from "../../graphql/client";
 import { useMessageCreatedSubscription } from "../../graphql/generated/codegen.generated";
 import AccordionLayout from "../../layouts/accordion.layout";
 import ErrorText from "../errors/error.text";
 
 import { Center, Loader, Stack, Group, Text } from "@mantine/core";
 import { useListState } from "@mantine/hooks";
-import { useEffect } from "react";
+import { useCallback } from "react";
 
-import type { MessageCreatedPayload } from "../../graphql/generated/codegen.generated";
+import type {
+  MessageCreatedPayload,
+  MessageCreatedSubscription,
+} from "../../graphql/generated/codegen.generated";
+import type { OnSubscriptionDataOptions } from "@apollo/client";
 
 const Feed = (): JSX.Element => {
-  const { data, loading, error } = useMessageCreatedSubscription();
   // we don't need to use more efficient data structure as we only operate with
   // 'FEED_MAX_SIZE' number of elements
   const [messages, messageHandlers] = useListState<MessageCreatedPayload>([]);
   const [providers] = useProviders();
+  const { loading, error } = useMessageCreatedSubscription({
+    onSubscriptionData: useCallback(
+      (data: OnSubscriptionDataOptions<MessageCreatedSubscription>) => {
+        void client.refetchQueries({ include: [`messageCount`] });
 
-  useEffect(() => {
-    if (
-      data &&
-      // record this message only if its provider is selected
-      providers.includes(data.messageCreated.provider)
-    ) {
-      messageHandlers.append(data.messageCreated);
+        const messagePayload = data.subscriptionData.data?.messageCreated;
 
-      if (messages.length >= FEED_MAX_SIZE) {
-        messageHandlers.shift();
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data]);
+        if (
+          messagePayload &&
+          // record this message only if its provider is selected
+          providers.includes(messagePayload.provider)
+        ) {
+          messageHandlers.append(messagePayload);
+
+          if (messages.length >= FEED_MAX_SIZE) {
+            messageHandlers.shift();
+          }
+        }
+      },
+      [messageHandlers, messages.length, providers],
+    ),
+  });
 
   return (
     <AccordionLayout


### PR DESCRIPTION
- [x] `messageCount` queries are refetched whenever `MessageCreatedSubscription` recieves new data
- [x] no recieved messages should be lost - fixed by using `onSubscriptionData` instead of custom `useEffect`